### PR TITLE
スタッフ用ページケア記録接続

### DIFF
--- a/backend/carebridge/caredata/urls.py
+++ b/backend/carebridge/caredata/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
-from .views import get_care_records, get_user_care_records, create_care_record, get_care_record_detail
+from .views import get_care_records, get_user_care_records, create_care_record, get_care_record_detail, delete_care_record, update_care_record
 
 urlpatterns = [
     path('care-records/', get_care_records),
     path('care-records/<uuid:uuid>/', get_user_care_records, name='get_user_care_records'),
     path('care-records/create/', create_care_record, name='create_care_record'),
-    path('care-records/detail/<int:id>/', get_care_record_detail, name='get_care_record_detail'),
+    path('care-records/update/<int:id>/', update_care_record, name='update_care_record'),  # 更新用エンドポイント
+    path('care-records/delete/<int:id>/', delete_care_record, name='delete_care_record'),  # 削除用エンドポイント
 ]

--- a/backend/carebridge/caredata/views.py
+++ b/backend/carebridge/caredata/views.py
@@ -72,3 +72,40 @@ def get_care_record_detail(request, id):
         return Response(serializer.data)
     except CareRecord.DoesNotExist:
         return Response({"error": "ケア記録が見つかりません"}, status=status.HTTP_404_NOT_FOUND)
+    
+@api_view(['DELETE'])
+def delete_care_record(request, id):
+    try:
+        print(f"Received request to delete care record with id: {id}")  # ログの追加
+
+        care_record = CareRecord.objects.get(id=id)
+        care_record.delete()
+        print(f"Successfully deleted care record with id: {id}")  # 成功ログ
+        return Response({"message": "ケア記録が削除されました"}, status=status.HTTP_204_NO_CONTENT)
+    except CareRecord.DoesNotExist:
+        print(f"Care record with id: {id} does not exist")  # 存在しないログ
+        return Response({"error": "ケア記録が見つかりません"}, status=status.HTTP_404_NOT_FOUND)
+    except Exception as e:
+        print(f"An error occurred while deleting care record with id: {id}: {str(e)}")  # エラーログ
+        return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    
+@api_view(['PUT'])
+def update_care_record(request, id):
+    try:
+        print(f"Received request to update care record with id: {id}")  # ログの追加
+
+        care_record = CareRecord.objects.get(id=id)
+        serializer = CareRecordSerializer(care_record, data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            print(f"Successfully updated care record with id: {id}")  # 成功ログ
+            return Response(serializer.data)
+        else:
+            print(f"Failed to update care record with id: {id} - Invalid data")  # 失敗ログ
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    except CareRecord.DoesNotExist:
+        print(f"Care record with id: {id} does not exist")  # 存在しないログ
+        return Response({"error": "ケア記録が見つかりません"}, status=status.HTTP_404_NOT_FOUND)
+    except Exception as e:
+        print(f"An error occurred while updating care record with id: {id}: {str(e)}")  # エラーログ
+        return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/frontend/src/app/staff/care-records/[uuid]/page.tsx
+++ b/frontend/src/app/staff/care-records/[uuid]/page.tsx
@@ -6,8 +6,9 @@ import Link from "next/link";
 import Modal from "../../../../components/modalCareRegister";
 import CareRegisterForm from "../../../../components/careRegisterForm";
 
+// ケア記録データの型定義
 type CareRecord = {
-  care_record_id: number;
+  id: number;
   date: string;
   meal: string;
   excretion: string;
@@ -19,6 +20,7 @@ type CareRecord = {
   staff: string; // スタッフのUUID
 };
 
+// ユーザー詳細情報の型定義
 type UserDetail = {
   uuid: string;
   user_id: string;
@@ -30,6 +32,7 @@ type UserDetail = {
   emergency_contact_phone: string;
 };
 
+// スタッフ詳細情報の型定義
 type StaffDetail = {
   uuid: string;
   staff_id: string;
@@ -38,19 +41,24 @@ type StaffDetail = {
 
 const CareRecordsPage = () => {
   const { uuid } = useParams(); // URLパラメータからUUIDを取得
-  const userUuid = Array.isArray(uuid) ? uuid[0] : uuid; // UUIDが配列の場合の対応
-  const [careRecords, setCareRecords] = useState<CareRecord[]>([]); // ケア記録データの状態変数
-  const [filteredCareRecords, setFilteredCareRecords] = useState<CareRecord[]>([]); // フィルタされたケア記録データの状態変数
-  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
-  const [selectedMonth, setSelectedMonth] = useState<number>(new Date().getMonth() + 1);
-  const [userDetail, setUserDetail] = useState<UserDetail | null>(null); // ユーザー詳細データの状態変数
-  const [staffDetails, setStaffDetails] = useState<{ [key: string]: StaffDetail }>({});
+  const userUuid = Array.isArray(uuid) ? uuid[0] : uuid; // UUIDが配列で返される場合に対応
+  const [careRecords, setCareRecords] = useState<CareRecord[]>([]); // 全てのケア記録を管理する状態変数
+  const [filteredCareRecords, setFilteredCareRecords] = useState<CareRecord[]>(
+    []
+  ); // フィルタリングされたケア記録を管理する状態変数
+  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear()); // 選択された年を管理する状態変数
+  const [selectedMonth, setSelectedMonth] = useState<number>(
+    new Date().getMonth() + 1
+  ); // 選択された月を管理する状態変数
+  const [userDetail, setUserDetail] = useState<UserDetail | null>(null); // ユーザー詳細情報を管理する状態変数
+  const [staffDetails, setStaffDetails] = useState<{
+    [key: string]: StaffDetail;
+  }>({}); // スタッフ詳細情報を管理する状態変数
   const [loading, setLoading] = useState(true); // ローディング状態を管理する状態変数
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false); // モーダルの開閉状態を管理する状態変数
-  const [selectedRecord, setSelectedRecord] = useState<CareRecord | null>(null); // 選択されたケア記録
+  const [selectedRecord, setSelectedRecord] = useState<CareRecord | null>(null); // 選択されたケア記録を管理する状態変数
 
-
-  // 初期ロード時にケア記録とユーザー詳細を取得
+  // コンポーネントがマウントされた時にケア記録とユーザー詳細を取得
   useEffect(() => {
     if (userUuid) {
       fetchCareRecords(userUuid);
@@ -58,44 +66,44 @@ const CareRecordsPage = () => {
     }
   }, [userUuid]);
 
-  // スタッフ情報を取得してマッピングを作成
+  // スタッフ情報を取得して状態に保存
   useEffect(() => {
     fetchStaffDetails();
   }, []);
 
-  // ケア記録をAPIから取得する関数
+  // APIからケア記録を取得
   const fetchCareRecords = async (userUuid: string) => {
     try {
       const response = await axios.get<CareRecord[]>(
         `http://localhost:8000/api/care-records/${userUuid}/`
       );
 
-      // 日付でソート（新しい順）
+      // 取得したケア記録を日付順にソート（新しい順）
       const sortedRecords = response.data.sort(
         (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
       );
 
       setCareRecords(sortedRecords);
-      setLoading(false);
+      setLoading(false); // ローディング状態を解除
     } catch (error) {
       console.error("ケアデータの取得中にエラーが発生しました");
-      setLoading(false);
+      setLoading(false); // ローディング状態を解除
     }
   };
 
-  // ユーザー詳細をAPIから取得する関数
+  // APIからユーザー詳細情報を取得
   const fetchUserDetail = async (userUuid: string) => {
     try {
       const response = await axios.get<UserDetail>(
         `http://localhost:8000/api/users/${userUuid}/`
       );
-      setUserDetail(response.data);
+      setUserDetail(response.data); // ユーザー詳細情報を状態にセット
     } catch (error) {
       console.error("ユーザー詳細の取得中にエラーが発生しました");
     }
   };
 
-  // スタッフ情報を取得してマッピングを作成する関数
+  // APIからスタッフ情報を取得して、UUIDをキーとするマッピングを作成
   const fetchStaffDetails = async () => {
     try {
       const response = await axios.get<StaffDetail[]>(
@@ -105,13 +113,13 @@ const CareRecordsPage = () => {
       response.data.forEach((staff) => {
         staffMap[staff.uuid] = staff;
       });
-      setStaffDetails(staffMap); // スタッフのUUIDをキーとするマッピングをセット
+      setStaffDetails(staffMap); // スタッフ情報を状態にセット
     } catch (error) {
       console.error("スタッフ情報の取得中にエラーが発生しました");
     }
   };
 
-  // 選択された年と月でケア記録をフィルタする関数
+  // 選択された年と月に基づいてケア記録をフィルタリング
   const filterCareRecords = useCallback(() => {
     const filtered = careRecords.filter((record) => {
       const recordDate = new Date(record.date);
@@ -120,16 +128,17 @@ const CareRecordsPage = () => {
         recordDate.getMonth() + 1 === selectedMonth
       );
     });
-    setFilteredCareRecords(filtered);
+    setFilteredCareRecords(filtered); // フィルタリングされたケア記録を状態にセット
   }, [careRecords, selectedYear, selectedMonth]);
 
-  // 年と月が選択されたときにケア記録をフィルタ
+  // 年または月が変更された際にケア記録をフィルタリング
   useEffect(() => {
     filterCareRecords();
-  }, [filterCareRecords]);  
+  }, [filterCareRecords]);
 
   // モーダルを開く関数（新規登録または編集用）
   const openModal = (record: CareRecord | null = null) => {
+    console.log("openModalで渡されたrecordオブジェクト:", record);
     setSelectedRecord(record); // 編集対象のケア記録をセット（新規の場合はnull）
     setIsModalOpen(true); // モーダルを表示
   };
@@ -137,8 +146,24 @@ const CareRecordsPage = () => {
   // モーダルを閉じる関数
   const closeModal = () => {
     setIsModalOpen(false); // モーダルを非表示
-    setSelectedRecord(null); // 編集対象をリセット
-    fetchCareRecords(userUuid); // モーダル閉じた後にリストを更新
+    setSelectedRecord(null); // 選択されたケア記録をリセット
+    fetchCareRecords(userUuid); // モーダル閉じた後にケア記録リストを更新
+  };
+
+  // ケア記録を削除する関数
+  const handleDelete = async (recordId: number) => {
+    console.log("handleDeleteで渡されたrecordId:", recordId);
+    const confirmDelete = confirm("このケア記録を削除してもよろしいですか？");
+    if (confirmDelete) {
+      try {
+        await axios.delete(
+          `http://localhost:8000/api/care-records/delete/${recordId}/`
+        );
+        fetchCareRecords(userUuid); // 削除後にケア記録を再取得
+      } catch (error) {
+        console.error("ケア記録の削除中にエラーが発生しました");
+      }
+    }
   };
 
   // ローディング中の表示
@@ -146,29 +171,32 @@ const CareRecordsPage = () => {
     return <div>Loading...</div>;
   }
 
-  // 年の選択肢を生成
+  // 選択可能な年のリストを生成
   const years = Array.from(
     new Array(5),
     (val, index) => new Date().getFullYear() - index
   );
 
-  // 月の選択肢を生成
+  // 選択可能な月のリストを生成
   const months = Array.from({ length: 12 }, (v, k) => k + 1);
 
   return (
     <div className="p-6 min-h-screen">
+      {/* 利用者一覧への戻りリンク */}
       <Link href="/staff/users">
         <button className="text-blue-800 mb-4">←利用者一覧に戻る</button>
       </Link>
       <div className="flex justify-between items-center mb-6">
         {userDetail && (
           <div className="flex items-center">
+            {/* ユーザー詳細情報の表示 */}
             <div className="mr-4">
               <h2 className="text-xl font-bold">{userDetail.user_id}</h2>
               <h2 className="text-xl font-bold">{userDetail.user_name}</h2>
               <p>{userDetail.user_name_kana}</p>
             </div>
             <div className="flex items-center">
+              {/* 年の選択 */}
               <label className="mr-2">年</label>
               <select
                 value={selectedYear}
@@ -181,6 +209,7 @@ const CareRecordsPage = () => {
                   </option>
                 ))}
               </select>
+              {/* 月の選択 */}
               <label className="mr-2">月</label>
               <select
                 value={selectedMonth}
@@ -196,6 +225,7 @@ const CareRecordsPage = () => {
             </div>
           </div>
         )}
+        {/* ケア登録ボタン */}
         <button
           onClick={() => openModal()}
           className="bg-secondary text-white px-4 py-2 rounded"
@@ -203,6 +233,7 @@ const CareRecordsPage = () => {
           ケア登録
         </button>
       </div>
+      {/* ケア記録の一覧テーブル */}
       <table className="min-w-full bg-white shadow rounded-lg">
         <thead>
           <tr>
@@ -215,11 +246,12 @@ const CareRecordsPage = () => {
             <th className="py-2 px-3 border-b">血圧（最高）</th>
             <th className="py-2 px-3 border-b">コメント</th>
             <th className="py-2 px-3 border-b">スタッフ名</th>
+            <th className="py-2 px-3 border-b">操作</th>
           </tr>
         </thead>
         <tbody>
           {filteredCareRecords.map((record) => (
-            <tr key={record.care_record_id}>
+            <tr key={record.id}>
               <td className="py-2 px-3 border-b">{record.date}</td>
               <td className="py-2 px-3 border-b">{record.meal}</td>
               <td className="py-2 px-3 border-b">{record.excretion}</td>
@@ -228,17 +260,37 @@ const CareRecordsPage = () => {
               <td className="py-2 px-3 border-b">{record.diastolic_bp}</td>
               <td className="py-2 px-3 border-b">{record.systolic_bp}</td>
               <td className="py-2 px-3 border-b">{record.comments}</td>
-              {/* スタッフUUIDを元に対応するスタッフ名を表示 */}
+              {/* スタッフの名前を表示 */}
               <td className="py-2 px-3 border-b">
                 {staffDetails[record.staff]?.staff_name || "不明"}
+              </td>
+              {/* 編集と削除のボタン */}
+              <td className="py-2 px-3 border-b">
+                <button
+                  onClick={() => openModal(record)}
+                  className="bg-accent2 text-white px-3 py-1 rounded mr-2"
+                >
+                  編集
+                </button>
+                <button
+                  onClick={() => handleDelete(record.id)}
+                  className="bg-accent text-white px-3 py-1 rounded"
+                >
+                  削除
+                </button>
               </td>
             </tr>
           ))}
         </tbody>
       </table>
+      {/* モーダルウィンドウ */}
       <Modal isOpen={isModalOpen} onClose={closeModal}>
         {userDetail && (
-          <CareRegisterForm user={userDetail} onClose={closeModal} />
+          <CareRegisterForm
+            user={userDetail}
+            onClose={closeModal}
+            record={selectedRecord}
+          />
         )}
       </Modal>
     </div>


### PR DESCRIPTION
- [x] 動作確認をしましたか？
- [x] ドキュメントやコメントを追加しましたか？

## 概要
<!-- 変更の概要を簡潔に記載してください -->
スタッフページでケア記録に編集・削除機能を追加
ケア記録登録時、ログインしているスタッフのIDで登録されるように変更

## 変更内容
<!-- 具体的に変更した内容を記載してください -->
- バックエンドに更新用と削除用エンドポイント作成→フロントにボタンをつけて接続
- ベタ打ちのスタッフUUIDで登録されるようになっていたので、firebaseのＵＩＤからスタッフデータを引っ張ってケアデータ登録に反映するように変更

## その他
<!-- その他の特記事項や補足情報があれば記載してください -->