### PR TITLE
スタッフページに出る利用者一覧を制限

### DIFF
--- a/frontend/src/app/staff/dashboard/page.tsx
+++ b/frontend/src/app/staff/dashboard/page.tsx
@@ -5,10 +5,21 @@ import Sidebar from "../../../components/sidebar";
 import DashboardChart from "../../../components/dashboardChart";
 import UserInfo from "../../../components/userInfo";
 import { useSearchParams } from "next/navigation";
+import { getAuth } from "firebase/auth";
 
 const Dashboard = () => {
   const [selectedUserUuid, setSelectedUserUuid] = useState<string | null>(null);
   const searchParams = useSearchParams(); // クエリパラメータを取得
+  const [firebaseUid, setFirebaseUid] = useState<string | null>(null);
+
+  // 初期表示時にFirebase UIDを取得
+  useEffect(() => {
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (user) {
+      setFirebaseUid(user.uid);
+    }
+  }, []);
 
   // 初期表示時にクエリパラメータからユーザーUUIDを取得してセット
   useEffect(() => {
@@ -25,10 +36,11 @@ const Dashboard = () => {
 
   return (
     <div className="flex h-screen">
-      {/* Sidebarに選択されたユーザーのUUIDを渡す */}
+      {/* SidebarにFirebase UIDと選択されたユーザーのUUIDを渡す */}
       <Sidebar
         onSelectUser={handleSelectUser}
         selectedUserUuid={selectedUserUuid}
+        firebaseUid={firebaseUid} // 追加
       />
       <div className="flex-1 p-4 overflow-y-auto">
         {selectedUserUuid ? (

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -5,6 +5,7 @@ import axios from "axios";
 type SidebarProps = {
   onSelectUser: (userUuid: string) => void;
   selectedUserUuid: string | null; // 現在選択されているユーザーのUUID
+  firebaseUid: string | null; // Firebase UID
 };
 
 type User = {
@@ -12,19 +13,25 @@ type User = {
   user_name: string;
 };
 
-const Sidebar = ({ onSelectUser, selectedUserUuid }: SidebarProps) => {
+const Sidebar = ({
+  onSelectUser,
+  selectedUserUuid,
+  firebaseUid,
+}: SidebarProps) => {
   const [users, setUsers] = useState<User[]>([]);
   const [searchTerm, setSearchTerm] = useState<string>("");
 
   useEffect(() => {
-    fetchUsers();
-  }, []);
+    if (firebaseUid) {
+      fetchUsers(firebaseUid);
+    }
+  }, [firebaseUid]);
 
   // ユーザー一覧を取得する非同期関数
-  const fetchUsers = async () => {
+  const fetchUsers = async (firebaseUid: string) => {
     try {
       const response = await axios.get<User[]>(
-        "http://localhost:8000/api/users/"
+        `http://localhost:8000/api/users/?firebase_uid=${firebaseUid}`
       );
       setUsers(response.data);
     } catch (error) {


### PR DESCRIPTION
- [x] 動作確認をしましたか？
- [x] ドキュメントやコメントを追加しましたか？

## 概要
<!-- 変更の概要を簡潔に記載してください -->
スタッフページで、施設にに紐づいたユーザーだけが表示されるように変更しました。

## 変更内容
<!-- 具体的に変更した内容を記載してください -->
バックエンドのユーザーのビューget_usersで、ログインしているスタッフのFirebase UIDを取得して紐づくユーザーを取得

## その他
<!-- その他の特記事項や補足情報があれば記載してください -->